### PR TITLE
Feature/discord integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/erkexzcx/bbtmvbot)](LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/erkexzcx/bbtmvbot)](https://goreportcard.com/report/github.com/erkexzcx/bbtmvbot)
 
-This bot scans the most popular flat rent portals for latest posts in Vilnius, which will be sent to subscribed users using Telegram app. This Telegram bot is suppossed to be multi-user, which means that you can host your own instance of this app and let others use your bot - either directly (private chat) or in group chats, so you and your significant other can get latest posts directly to your group chat.
+This bot scans the most popular flat rent portals for latest posts in Vilnius, which will be sent to subscribed users using Telegram app or post messages to Discord channel. This Telegram bot is supposed to be multi-user, which means that you can host your own instance of this app and let others use your bot - either directly (private chat) or in group chats, so you and your significant other can get latest posts directly to your group chat.
 
 Only `x86_64` architecture and Docker is supported. I suggest having at least 1GB RAM for this application to work, since it uses headless chromium browser and opens 7 tabs (websites) all at once for parsing.
 
@@ -26,7 +26,7 @@ Once you set-up bot, you should have your bot's Telegram **API key**.
 
 Out of `config.example.yml` create `config.yml` file with the following contents (see my added comments below):
 
-```
+```yml
 # Log level - set it to `info`, unless you are developing it, then `debug`
 log_level: info # debug, info, warn, error
 
@@ -36,8 +36,16 @@ data_dir: data
 # Telegram API key - BotFather will tell you the key
 telegram_api_key: 1234567890:6xYrZZ2s_jrki5qgr8OxVBS566z2ZGF4Co7
 
+# Discord config example
+DiscordConfig:
+  webhook: https://discord.com/api/webhooks/123
+  price_from: 300
+  price_to: 900
+  rooms_from: 1
+  rooms_to: 5
+
 # User agent (prefer Windows desktop browser) - Ensure it uses __latest__ Windows Chrome user-agent to avoid suspicion by anti-bot systems
-user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36
+user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
 ```
 
 In case I forget to update above config example - always see `config.example.yml` for latest changes.
@@ -56,7 +64,7 @@ bbtmvbot
 
 Now this is how your `docker-compose.yml` should look like:
 
-```
+```yaml
 services:
 
   bbtmvbot:
@@ -72,6 +80,14 @@ services:
 
 Simply start it, then go to Telegram and issue `/config` (or whatever) command for this bot. Enjoy!
 
+## Using Discord instead of Telegram
+
+You can also use discord instead of telegram. However, in that case, only one discord channel will receive notifications.
+
+To use Discord, instead of Telegram, the only thing that is needed is to provide config in the `config.yml` file. `webhook` url needs to be provided. Only Discord server admin can generate this using *Integrations* setting in the server settings. 
+
+Additionally, `price_from`, `price_to`, `rooms_from` and `rooms_to` fields are needed to filter out rental posts.
+
 ## (Optional) set-up logs DB
 
 If you have no plans to contribute to this project (either by raising issues or pull requests), there is no need to do this step. Simply enjoy the application and I will _try_ to keep it up to date.
@@ -82,7 +98,7 @@ One way to tackle this problem is to set-up logs database. I prefer [OpenObserve
 
 Here is how you can expand your `docker-compose.yml` by appending below contents:
 
-```
+```yaml
   openobserve:
     image: public.ecr.aws/zinclabs/openobserve
     container_name: openobserve

--- a/config.example.yml
+++ b/config.example.yml
@@ -7,8 +7,16 @@
 # Telegram API key:
 telegram_api_key: 1234567890:6xYrZZ2s_jrki5qgr8OxVBS566z2ZGF4Co7
 
+# Discord config example
+DiscordConfig:
+  webhook: https://discord.com/api/webhooks/123
+  price_from: 300
+  price_to: 900
+  rooms_from: 1
+  rooms_to: 5
+
 # User agent (prefer Windows desktop browser)
-user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36
+user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
 
 # Prometheus metrics settings
 #metrics:

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,15 @@ type Config struct {
 		Interval  time.Duration `yaml:"interval"`
 		UserAgent string        `yaml:"user_agent"`
 	} `yaml:"parsing"`
+	DiscordConfig *DiscordConfig `yaml:"DiscordConfig"`
+}
+
+type DiscordConfig struct {
+	WebHook 	string `yaml:"webhook"`
+	PriceFrom 	int `yaml:"price_from"`
+	PriceTo 	int `yaml:"price_to"`
+	RoomsFrom 	int `yaml:"rooms_from"`
+	RoomsTo 	int `yaml:"rooms_to"`
 }
 
 func New(path string) (*Config, error) {
@@ -52,8 +61,8 @@ func New(path string) (*Config, error) {
 	c.LogLevel = strings.ToLower(c.LogLevel)
 
 	// Validation
-	if len(c.TelegramApiKey) == 0 {
-		return nil, errors.New("missing telegram_api_key")
+	if len(c.TelegramApiKey) == 0 && c.DiscordConfig == nil {
+		return nil, errors.New("missing telegram_api_key or DiscordConfig")
 	}
 	if _, _, err := net.SplitHostPort(c.Metrics.Bind); err != nil {
 		return nil, errors.New("missing or invalid metrics_bind")

--- a/discord.go
+++ b/discord.go
@@ -1,0 +1,41 @@
+package bbtmvbot
+
+import (
+	"bbtmvbot/website"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+func filterPost(post *website.Post, priceFrom int, priceTo int, roomsFrom int, roomsTo int) bool {
+	if post.Price <= priceFrom || post.Price >= priceTo || post.Rooms <= roomsFrom || post.Rooms >= roomsTo {
+		return false
+	}
+	return true
+}
+
+func sendDiscord(post *website.Payload, url string) error {
+	startTime := time.Now()
+
+    jsonData, err := json.Marshal(post)
+    if err != nil {
+        return err
+    }
+
+    resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
+    if err != nil {
+        return err
+    }
+    defer resp.Body.Close()
+
+    _, err = io.ReadAll(resp.Body)
+    if err != nil {
+        return err
+    }
+	elapsedTime = time.Since(startTime)
+
+	time.Sleep(30*time.Millisecond - elapsedTime)
+	return nil
+}


### PR DESCRIPTION
# Add Discord integration

When `telegram_api_key` is not provided fallback to using Discord

For this, discord config needs to be provided in the `config.yml` file:

```yml
DiscordConfig:
  webhook: https://discord.com/api/webhooks/123
  price_from: 300
  price_to: 900
  rooms_from: 1
  rooms_to: 5
```

Webhook URL is generated by discord server admin in the *Integrations* tab.